### PR TITLE
Make `message` property on RubyError non-enumerable

### DIFF
--- a/ext/mini_racer_extension/mini_racer_extension.cc
+++ b/ext/mini_racer_extension/mini_racer_extension.cc
@@ -1234,7 +1234,7 @@ static void throw_ruby_error(Isolate* isolate, ContextInfo* context_info, VALUE 
     Local<String> v8Message;
     if(!String::NewFromUtf8(isolate, RSTRING_PTR(message), NewStringType::kNormal, RSTRING_LENINT(message)).ToLocal(&v8Message))
         v8Message = String::NewFromUtf8(isolate, "(( exception message was too long, dropped ))").ToLocalChecked();
-    if(errorInstance->CreateDataProperty(context, String::NewFromUtf8Literal(isolate, "message"), v8Message).IsNothing())
+    if(errorInstance->DefineOwnProperty(context, String::NewFromUtf8Literal(isolate, "message"), v8Message, v8::PropertyAttribute::DontEnum).IsNothing())
         return;
     Local<Value> captureTarget = errorInstance;
     if(context_info->capture_stack_trace.Get(isolate)->Call(context, v8::Undefined(isolate), 1, &captureTarget).IsEmpty())


### PR DESCRIPTION
This is a minor change for consistency. Compare with `Object.getOwnPropertyDescriptor(new Error("foo"), "message")`.

(Inconsistency discovered by `geyser_soze#0002` on Discord while debugging a database issue)