### PR TITLE
Rewrite timeout tracking to be in cpu-time instead of wall-time

### DIFF
--- a/ext/mini_racer_extension/mini_racer_extension.cc
+++ b/ext/mini_racer_extension/mini_racer_extension.cc
@@ -1698,45 +1698,12 @@ rb_heap_snapshot(VALUE self, VALUE file) {
     return Qtrue;
 }
 
-// 1 jiffie = 1 µs for now
-#define JIFFIES_PER_SECOND 1000000 // 1'000'000
-#define NANOSECONDS_PER_JIFFIE 1000 // 1'000
-
-static void
-v8_update_cpu_time(Isolate* isolate, ContextInfo* context_info) {
-    struct timespec now;
-    int time_status = clock_gettime(CLOCK_THREAD_CPUTIME_ID, &now);
-    assert(time_status == 0); // can only hit on EOVERFLOW (which shouldn't happen) and EINVAL (kernel too old; don't care right now)
-
-    struct timespec delta = {
-        .tv_sec = now.tv_sec - context_info->cpu_time_reference.tv_sec,
-        .tv_nsec = now.tv_nsec - context_info->cpu_time_reference.tv_nsec, // this type is defined as `long` by POSIX, so negative values are fine here.
-    };
-
-    // lower from timespec to to a number of jiffies
-    unsigned long elapsed_time = delta.tv_sec * JIFFIES_PER_SECOND + delta.tv_nsec / NANOSECONDS_PER_JIFFIE;
-
-    context_info->cpu_time_reference = now;
-    (void) context_info->cpu_nanos.fetch_add(elapsed_time, std::memory_order_relaxed);
-}
-
-static void
-v8_update_cpu_time_callback(Isolate* isolate, void* ud) {
-    ContextInfo* context_info = reinterpret_cast<ContextInfo*>(ud);
-    v8_update_cpu_time(isolate, context_info);
-}
-
 static VALUE
-rb_context_update_cpu_time(VALUE self) {
-    ContextInfo* context_info;
-    Data_Get_Struct(self, ContextInfo, context_info);
-
-    unsigned long current_time = context_info->cpu_nanos.load(std::memory_order_relaxed);
-
-    Isolate* isolate = context_info->isolate_info->isolate;
-    isolate->RequestInterrupt(&v8_update_cpu_time_callback, reinterpret_cast<void*>(context_info));
-
-    return LONG2NUM(current_time);
+rb_context_current_thread_clock(VALUE self) {
+	clockid_t thread_clock;
+	int ok = pthread_getcpuclockid(pthread_self(), &thread_clock);
+	assert(ok == 0 && "couldn't grab current thread's cpu clock"); // TODO: rb_raise an error instead
+	return INT2NUM(thread_clock);
 }
 
 static VALUE
@@ -1971,7 +1938,7 @@ extern "C" {
         rb_define_private_method(rb_cContext, "call_unsafe", (VALUE(*)(...))&rb_context_call_unsafe, -1);
         rb_define_private_method(rb_cContext, "isolate_mutex", (VALUE(*)(...))&rb_context_isolate_mutex, 0);
         rb_define_private_method(rb_cContext, "init_unsafe",(VALUE(*)(...))&rb_context_init_unsafe, 2);
-        rb_define_private_method(rb_cContext, "update_cpu_time", (VALUE(*)(...))&rb_context_update_cpu_time, 0);
+        rb_define_private_method(rb_cContext, "current_thread_clock", (VALUE(*)(...))&rb_context_current_thread_clock, 0);
 
         rb_define_alloc_func(rb_cContext, allocate);
         rb_define_alloc_func(rb_cSnapshot, allocate_snapshot);

--- a/lib/mini_racer.rb
+++ b/lib/mini_racer.rb
@@ -360,7 +360,7 @@ module MiniRacer
       t = Thread.new do
         begin
           while true do
-            result = IO.select([rp],[],[],0.1) # seconds # TODO: Adjust this interval depending on the remaining wall/cpu clock; required for tests
+            result = IO.select([rp],[],[],0.05) # seconds # TODO: Adjust this interval depending on the remaining wall/cpu clock; required for tests
             break if result # operation completed
             current_monotonic_time = Process.clock_gettime Process::CLOCK_MONOTONIC, :millisecond
             if thread_clock then

--- a/lib/mini_racer.rb
+++ b/lib/mini_racer.rb
@@ -150,7 +150,6 @@ module MiniRacer
 
       @functions = {}
       @timeout = nil
-      @cputime_limit = nil
       @max_memory = nil
       @current_exception = nil
       @timeout = timeout

--- a/lib/mini_racer.rb
+++ b/lib/mini_racer.rb
@@ -349,10 +349,15 @@ module MiniRacer
 
       t = Thread.new do
         begin
-          result = IO.select([rp],[],[],(@timeout/1000.0))
-          if !result
-            mutex.synchronize do
-              stop unless done
+          while true do
+            result = IO.select([rp],[],[],0.1)
+            break if result
+            cpu_time = update_cpu_time
+            # cpu time is in micros (e-6), timeout is in millis (e-3);
+            if cpu_time / 1000 >= @timeout
+              mutex.synchronize do
+                stop unless done
+              end
             end
           end
         rescue => e

--- a/lib/mini_racer.rb
+++ b/lib/mini_racer.rb
@@ -350,7 +350,7 @@ module MiniRacer
       t = Thread.new do
         begin
           while true do
-            result = IO.select([rp],[],[],0.1)
+            result = IO.select([rp],[],[],0.1) # seconds
             break if result
             cpu_time = update_cpu_time
             # cpu time is in micros (e-6), timeout is in millis (e-3);

--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -119,7 +119,7 @@ class MiniRacerTest < Minitest::Test
   def test_it_can_hit_cputime_limit_during_serialization
     context = MiniRacer::Context.new(timeout: 30,cputime_limit: 20)
 
-    Timeout::timeout(0.025) do
+    Timeout::timeout(0.250) do
       assert_raises(MiniRacer::ScriptTerminatedError) do
         context.eval 'var a = {get a(){ while(true); }}; a'
       end
@@ -129,7 +129,7 @@ class MiniRacerTest < Minitest::Test
   def test_it_can_limit_cputime
     context = MiniRacer::Context.new(timeout: 20, cputime_limit: 2)
     # our test should raise after the cputime_limit, but before our timeout
-    Timeout::timeout(0.010) do
+    Timeout::timeout(0.100) do
       assert_raises do
         context.eval('while(true){}')
       end

--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -102,15 +102,14 @@ class MiniRacerTest < Minitest::Test
   end
 
   def test_it_can_timeout_during_serialization
-    context = MiniRacer::Context.new(timeout: 500)
+    context = MiniRacer::Context.new(timeout: 20)
 
     assert_raises(MiniRacer::ScriptTerminatedError) do
       context.eval 'var a = {get a(){ while(true); }}; a'
     end
   end
 
-  def test_it_can_automatically_time_out_context
-    # 2 millisecs is a very short timeout but we don't want test running forever
+  def test_it_can_time_out_js_eval
     context = MiniRacer::Context.new(timeout: 2)
     assert_raises do
       context.eval('while(true){}')


### PR DESCRIPTION
### Problem

Script time execution tracking is currently done with wall-clock-time, not cputime. This means differences in the OS scheduler affect script time execution.

### Context

~~This initial implementation is not cross-platform (`clock_gettime` is a POSIX API). Additionally, this implementation does not yet use the `pthread_getcpuclockid` function discovered after the implementation work was already complete.~~

~~The failing timeout test is due the timeout being induced by  `sleep 0.1`, which does not take up any CPU time.~~

This implementation uses `pthread_getcpuclockid` to obtain the CPU clock for the thread running V8 code, then continually polls that clock to check for the execution timeout.
