### PR TITLE
Update darwin platforms for ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - '10.15'
-          - '11.0'
+          - '12'
+          - '13'
+          - 'latest'
         platform:
           - x86_64
           # arm64


### PR DESCRIPTION
### Problem

Our mac platform runners no longer work.

### Context

<!-- Additional context about how this fix was implemented. delete section if not needed -->
